### PR TITLE
use the Vagrantfile with vagrant-proxyconf behind a firewall.

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -6,7 +6,28 @@ st2ver="0.6.0"
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+if !Vagrant.has_plugin?('vagrant-proxyconf') && ENV['NO_VAGRANT_PROXY'].nil?
+  raise "
+  *******                                                          *******
+    Can't continue.  Please install vagrant-proxyconf,
+    \$ vagrant plugin install vagrant-proxyconf
+
+    or run to ignore check run command:
+
+    \$ NO_VAGRANT_PROXY=true vagrant up
+  *******                                                          *******
+  "
+end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+    # proxy setup if configured
+    # Setting the proxy action up
+    if Vagrant.has_plugin?('vagrant-proxyconf')
+      config.proxy.https = ENV['HTTPS_PROXY'] unless ENV['HTTPS_PROXY'].nil?
+      config.proxy.http = ENV['HTTP_PROXY'] unless ENV['HTTP_PROXY'].nil?
+      config.proxy.no_proxy = ENV['NO_PROXY'].nil? ? ENV['NO_PROXY'] : \
+                              "localhost,127.0.0.1,10.0.0.1,169.254.169.254"
+    end
 
     config.vm.box = "ubuntu/trusty64"
     config.vm.hostname = "st2express"


### PR DESCRIPTION
Hey!, Just trying to set this up locally.  Ran into some issues with being behind a proxy so I thought I throw in a fix for missing proxy handling on your image.

Not, you can by pass this if you don't want to use the vagrant-proxyconf plugin with the command:

NO_VAGRANT_PROXY=true vagrant up