### PR TITLE
incorrect EXPOSE port syntax/comment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,5 +27,7 @@ ADD . /root/st2/
 
 RUN bash -c 'chmod +x /root/st2/start.sh'
 
-EXPOSE 9100  # auth service
-EXPOSE 9101  # api service
+# auth service
+EXPOSE 9100
+# api server
+EXPOSE 9101


### PR DESCRIPTION
```
==============================

      _   ___     ____  _  __ 
     | | |__ \   / __ \| |/ / 
  ___| |_   ) | | |  | | ' /  
 / __| __| / /  | |  | |  <   
 \__ \ |_ / /_  | |__| | . \  
 |___/\__|____|  \____/|_|\_\ 

  st2 is installed and ready  
 ---> 670fe185498d
Removing intermediate container b5fd046bb9f5
Step 8 : ADD . /root/st2/
 ---> 4a49fa064b16
Removing intermediate container 75236ee31c22
Step 9 : RUN bash -c 'chmod +x /root/st2/start.sh'
 ---> Running in 5581f0e0864a
 ---> fb47b6ba338c
Removing intermediate container 5581f0e0864a
Step 10 : EXPOSE 9100 # auth service
INFO[0692] Invalid containerPort: #   
```