### PR TITLE
Ver envvar

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -22,6 +22,34 @@ The supervisor script to start,stop,restart,reload, and, clean st2 is run like s
 
     st2ctl start|stop|status|restart|reload|clean
 
+### Environment Variables
+Environment variables can be used to enable or disable certain features of the StackStorm deployment.
+
+* WEBUI - Set to 0 to skip ui installation.  
+    * DEFAULT: 1
+* ST2VER - The version of St2 to install.
+    * DEFAULT: 0.8dev
+* HOSTNAME - the hostname to give the VM. 
+    * DEFAULT: st2express
+
+#### Usage
+
+`HOSTNAME=st2test ST2VER=0.8 WEBUI=0 vagrant up`
+
+If the hostname has been specified during `vagrant up` then it either needs to be exported or specified for all future vagrant commands related to that VM.
+
+Example:
+If the following was used to provision the VM:
+`HOSTNAME=st2test vagrant up`
+
+then status would need to be run like so:
+`HOSTNAME=st2test vagrant status`
+
+and destroy:
+`HOSTNAME=st2test vagrant destroy`
+
+The alternative is to simply `export HOSTNAME=st2test`
+
 ### Logging
 This installation makes use of the syslog logging configuration files for each of the St2 components.  You will find the logs in:
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-st2ver   = ENV['ST2VER'] ? ENV['ST2VER'] : '0.8dev'
+st2ver   = ENV['ST2VER'] ? ENV['ST2VER'] : '0.8.0'
 webui    = ENV['WEBUI'] ? ENV['WEBUI'] : '1'
 hostname = ENV['HOSTNAME'] ? ENV['HOSTNAME'] : 'st2express'
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-st2ver="0.8dev"
+st2ver   = ENV['ST2VER'] ? ENV['ST2VER'] : '0.8dev'
+webui    = ENV['WEBUI'] ? ENV['WEBUI'] : '1'
+hostname = ENV['HOSTNAME'] ? ENV['HOSTNAME'] : 'st2express'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -31,13 +33,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     config.vm.box = "ubuntu/trusty64"
-    config.vm.hostname = "st2express"
+    config.vm.hostname = "#{hostname}"
 
-    config.vm.define "st2express" do |q|
+    config.vm.define "#{hostname}" do |q|
     end
 
     config.vm.provider :virtualbox do |vb|
-      vb.name = "st2express"
+      vb.name = "#{hostname}"
       vb.memory = 2048
       vb.cpus = 1
     end
@@ -47,9 +49,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # Start shell provisioning
     config.vm.provision :shell, :inline => "curl -sS -k -O https://ops.stackstorm.net/releases/st2/#{st2ver}/st2_deploy.sh"
-    config.vm.provision :shell, :inline => "bash st2_deploy.sh #{st2ver}"
+    config.vm.provision :shell, :inline => "INSTALL_WEBUI=#{webui} bash -c '. st2_deploy.sh #{st2ver}'"
     config.vm.provision :shell, :path => "rsyslog.sh"
-    config.vm.provision :shell, :path => "sensu_server.sh"
-    config.vm.provision :shell, :path => "sensu_client.sh"
+    #config.vm.provision :shell, :path => "sensu_server.sh"
+    #config.vm.provision :shell, :path => "sensu_client.sh"
     config.vm.provision :shell, :path => "validate.sh"
 end

--- a/vagrant/validate.sh
+++ b/vagrant/validate.sh
@@ -1,10 +1,14 @@
-st2 run core.local stuff -a > /dev/null
+echo "========= Verifying St2 ========="
+sleep 10
+st2ctl status
+echo "========== Test Action =========="
+st2 run core.local hostname
 ACTIONEXIT=$?
 
 echo "=============================="
 echo ""
 
-if [ ! "${ACTIONEXIT}" == 0 ]
+if [ ${ACTIONEXIT} -ne 0 ]
 then
   echo "ERROR!" 
   echo "Something went wrong, st2 failed to start"


### PR DESCRIPTION
This PR adds support for passing in environment variables for common settings used in provisioning.

## Variables

* WEBUI - Set to 0 to skip ui installation.  
    * DEFAULT: 1
* ST2VER - The version of St2 to install.
    * DEFAULT: 0.8dev
* HOSTNAME - the hostname to give the VM. 
    * DEFAULT: st2express

## Usage

`HOSTNAME=st2test ST2VER=0.7 WEBUI=0 vagrant up`

If the hostname has been specified during `vagrant up` then it either needs to be exported or specified for all future vagrant commands related to that VM.

Example:
If the following was used to provision the VM:
`HOSTNAME=st2test vagrant up`

then status would need to be run like so:
`HOSTNAME=st2test vagrant status`

and destroy:
`HOSTNAME=st2test vagrant destroy`

The alternative is to simply `export HOSTNAME=st2test`