### PR TITLE
updating Dockerfile to run base ubuntu:14.04 image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM dockerfile/ubuntu
+FROM ubuntu:14.04
 
 # Disable prompts
 ENV DEBIAN_FRONTEND noninteractive
@@ -10,7 +10,7 @@ RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
 # Install Python
 RUN \
   apt-get update && \
-    apt-get install -y python python-dev python-pip python-virtualenv openssh-server && \
+    apt-get install -y curl python python-dev python-pip python-virtualenv openssh-server && \
       apt-get install -y python-prettytable python-yaml && \
         rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
using the trusty base ubuntu image on the docker hub. i tried building the Dockerfile as is with the dockerfile/ubuntu image and got this error

```
webapp@docker:~/st2express/docker$ docker build -t st2 .
Sending build context to Docker daemon 7.168 kB
Sending build context to Docker daemon
Step 0 : FROM dockerfile/ubuntu
Pulling repository dockerfile/ubuntu
2015/05/26 03:22:48 Error: image dockerfile/ubuntu not found
```

docker version is 1.3.1, build 4e9bbfa. i also added curl as a dependency but it all builds/runs smoothly now