### PR TITLE
Added sshpass for automating testing in docker linked envs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,8 @@ RUN \
   apt-get update && \
     apt-get install -y curl python python-dev python-pip python-virtualenv openssh-server && \
       apt-get install -y python-prettytable python-yaml && \
-        rm -rf /var/lib/apt/lists/*
+        apt-get install -y sshpass && \
+          rm -rf /var/lib/apt/lists/*
 
 # Set environment variable to Docker
 ENV CONTAINER DOCKER


### PR DESCRIPTION
Hello,

Guys who are using docker-expose might be interested (@lakshmi-kannan :).
I've added ssh pass which actually allows to do smth like this

```yaml
st2:
  image: st2
  links:
   - chef
  ports:
   - "8080:8080"
   - "9100:9100"
   - "9101:9101"
  command: >
          /bin/bash -c "DEBIAN_FRONTEND=noninteractive apt-get install sshpass;
          sshpass -pstanley ssh-copy-id -i /home/stanley/.ssh/stanley_rsa -oStrictHostKeyChecking=no stanley@chef;
          /root/st2/start.sh; sleep infinity"
  volumes:
   - ./:/opt/stackstorm/packs/chef
chef:
  build: ./etc
```

My `chef` container has user stanley with password stanley, the code propagates keys on container startup, so that I'm automatically able to use `st2 run core.remote' for example.
And the details for `chef` container https://gist.github.com/dennybaa/f3196743d3da6557de8a
