### PR TITLE
Fail docker build and exit with non-zero if st2_deploy.sh script fails

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /root && curl -sS -k -O https://ops.stackstorm.net/releases/st2/scripts/s
 
 RUN bash -c 'chmod +x /root/st2_deploy.sh'
 
-RUN bash -c '/root/st2_deploy.sh 0.9.2';'bash'
+RUN bash -c '/root/st2_deploy.sh 0.9.2 || exit 2'
 
 ADD . /root/st2/
 


### PR DESCRIPTION
Previously we didn't do that so the `docker build` command would still proceed with the next steps even if st2_deploy.sh failed.